### PR TITLE
Issue 0: Set up Rust tooling and test infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      - name: Run tests
+        run: cargo test --release
+
   test-python:
     runs-on: ubuntu-latest
     steps:

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2021"
+max_width = 100
+use_small_heuristics = "Default"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,8 @@ Linux multimedia server that handles video/audio streams. After portal provides 
 3. Receive video buffers via stream callbacks
 4. Convert buffers to BGRA numpy arrays
 
-### zbus
-Rust async D-Bus library. Used for portal communication. Requires tokio runtime.
+### ASHPD
+High-level Rust wrapper for xdg-desktop-portal (https://github.com/bilelmoussaoui/ashpd). Provides idiomatic async API for portal communication including ScreenCast. Uses zbus internally.
 
 ### pipewire-rs
 Official Rust bindings for PipeWire. Handles stream setup and frame reception.
@@ -81,10 +81,12 @@ Official Rust bindings for PipeWire. Handles stream setup and frame reception.
 | Component | Status | Notes |
 |-----------|--------|-------|
 | Project structure | Done | Cargo.toml, pyproject.toml, CI/CD |
+| Rust tooling | Done | rust-toolchain.toml (1.83.0), .rustfmt.toml, clippy |
+| Unit tests | Setup | Test infrastructure in place, basic tests for error/lib |
 | `is_available()` | Partial | Checks WAYLAND_DISPLAY, TODO: check portal |
 | `PortalCapture` | Skeleton | Struct defined, methods are stubs |
 | `CaptureStream` | Skeleton | Struct defined, methods are stubs |
-| D-Bus integration | TODO | Need zbus implementation |
+| D-Bus integration | TODO | Using ASHPD library |
 | PipeWire capture | TODO | Need pipewire-rs implementation |
 | Wheel building | Setup | CI configured, untested |
 
@@ -126,8 +128,17 @@ maturin build --release
 ```bash
 cargo fmt --check
 cargo clippy -- -D warnings
+cargo test
 cargo build --release
 ```
+
+### Contributing via Pull Requests
+All changes should be made via pull requests:
+1. Create a feature branch: `git checkout -b issue-N-description`
+2. Make changes and ensure all checks pass
+3. Commit with descriptive message
+4. Push and create PR: `gh pr create`
+5. Merge after review
 
 ## Code Style
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py39"] }
 numpy = "0.22"
 pipewire = "0.8"
-zbus = { version = "4", default-features = false, features = ["tokio"] }
+ashpd = { version = "0.11", default-features = false, features = ["tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 parking_lot = "0.12"
 thiserror = "2"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.83.0"
+components = ["rustfmt", "clippy"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,3 +31,26 @@ impl From<CaptureError> for PyErr {
         PyRuntimeError::new_err(err.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display() {
+        let err = CaptureError::UserCancelled;
+        assert_eq!(err.to_string(), "User cancelled window selection");
+    }
+
+    #[test]
+    fn test_portal_not_available_error() {
+        let err = CaptureError::PortalNotAvailable("test reason".to_string());
+        assert_eq!(err.to_string(), "Portal not available: test reason");
+    }
+
+    #[test]
+    fn test_pipewire_error() {
+        let err = CaptureError::PipeWire("connection failed".to_string());
+        assert_eq!(err.to_string(), "PipeWire error: connection failed");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,13 @@
 
 use pyo3::prelude::*;
 
+mod error;
 mod portal;
 mod stream;
-mod error;
 
+pub use error::CaptureError;
 pub use portal::PortalCapture;
 pub use stream::CaptureStream;
-pub use error::CaptureError;
 
 /// Check if PipeWire capture is available on this system.
 ///
@@ -30,4 +30,25 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PortalCapture>()?;
     m.add_class::<CaptureStream>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_available_without_wayland() {
+        // When WAYLAND_DISPLAY is not set, should return false
+        std::env::remove_var("WAYLAND_DISPLAY");
+        assert!(!is_available());
+    }
+
+    #[test]
+    fn test_is_available_with_wayland() {
+        // When WAYLAND_DISPLAY is set, should return true
+        std::env::set_var("WAYLAND_DISPLAY", "wayland-0");
+        assert!(is_available());
+        // Clean up
+        std::env::remove_var("WAYLAND_DISPLAY");
+    }
 }

--- a/src/portal.rs
+++ b/src/portal.rs
@@ -5,14 +5,13 @@
 
 use pyo3::prelude::*;
 
-use crate::error::CaptureError;
-
 /// Portal-based window selection for screen capture.
 ///
 /// Uses xdg-desktop-portal ScreenCast interface to show a system
 /// window picker dialog and obtain a PipeWire stream for the
 /// selected window.
 #[pyclass]
+#[derive(Default)]
 pub struct PortalCapture {
     // TODO: Add fields for:
     // - D-Bus connection
@@ -72,14 +71,5 @@ impl PortalCapture {
         self.fd = None;
         self.node_id = None;
         Ok(())
-    }
-}
-
-impl Default for PortalCapture {
-    fn default() -> Self {
-        Self {
-            fd: None,
-            node_id: None,
-        }
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles capturing video frames from a PipeWire stream.
 
-use numpy::{PyArray3, PyArrayMethods};
+use numpy::PyArray3;
 use pyo3::prelude::*;
 
 /// PipeWire-based video capture stream.
@@ -11,8 +11,11 @@ use pyo3::prelude::*;
 /// Frames are returned as numpy arrays in BGRA format.
 #[pyclass]
 pub struct CaptureStream {
+    #[allow(dead_code)]
     fd: i32,
+    #[allow(dead_code)]
     node_id: u32,
+    #[allow(dead_code)]
     capture_interval: f64,
     running: bool,
     window_closed: bool,
@@ -56,7 +59,7 @@ impl CaptureStream {
     ///
     /// Returns a numpy array of shape (height, width, 4) in BGRA format,
     /// or None if no frame is available yet.
-    pub fn get_frame<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyArray3<u8>>>> {
+    pub fn get_frame<'py>(&self, _py: Python<'py>) -> PyResult<Option<Bound<'py, PyArray3<u8>>>> {
         // TODO: Return the latest frame from the buffer
         // For now, return None
         Ok(None)


### PR DESCRIPTION
## Summary
- Add `rust-toolchain.toml` pinning Rust 1.83.0 with rustfmt/clippy components
- Add `.rustfmt.toml` for consistent code formatting
- Replace `zbus` with `ashpd` (high-level xdg-desktop-portal wrapper) for simpler portal integration
- Add `cargo test` step to CI workflow
- Add unit tests for error types and `is_available()` function
- Fix clippy warnings (unused imports, dead code, derivable impl)
- Update `CLAUDE.md` with PR workflow and current implementation status

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (5 tests)
- [x] `cargo build --release` succeeds