### PR TITLE
Set up manylinux wheel building (#3)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,23 +10,16 @@ permissions:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - target: x86_64
-            # Uses default manylinux_2_34 container (AlmaLinux 9)
+            runner: ubuntu-latest
           - target: aarch64
-            # Use native aarch64 container with QEMU emulation instead of cross-compilation
-            container: quay.io/pypa/manylinux_2_34_aarch64
+            runner: ubuntu-24.04-arm  # Native ARM64 runner (much faster than QEMU)
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        if: matrix.target == 'aarch64'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -39,7 +32,6 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist
           manylinux: "2_34"
-          container: ${{ matrix.container || '' }}
           before-script-linux: |
             # Install PipeWire and clang dev libraries (AlmaLinux 9 / manylinux_2_34)
             dnf install -y dnf-plugins-core


### PR DESCRIPTION
## Summary

- Switch from `manylinux_2_28` to `manylinux_2_34` (AlmaLinux 9) for newer PipeWire headers
- Use native ARM64 runners (`ubuntu-24.04-arm`) instead of QEMU emulation for fast aarch64 builds
- Use `dnf` with CRB repo for AlmaLinux 9 package installation
- Add `test-wheels` job to verify wheels can be imported before publishing

## Changes

### PipeWire Version Compatibility
The `pipewire-rs 0.8` crate requires PipeWire headers with SPA type definitions that were added in newer versions. AlmaLinux 8's PipeWire 0.3.6 was too old. AlmaLinux 9 (manylinux_2_34) has PipeWire 0.3.52+ which works.

### Native ARM64 Builds
Instead of slow QEMU emulation, we now use GitHub's native ARM64 runners (`ubuntu-24.04-arm`). Build times:
- x86_64: ~2m43s
- aarch64: ~3m23s (was 10+ minutes with QEMU)

### Package Installation
```yaml
before-script-linux: |
  dnf install -y dnf-plugins-core
  dnf config-manager --set-enabled crb
  dnf install -y pipewire-devel clang-devel
```

## Test Results

Workflow run #20876358555 passed:
- build-linux (x86_64) - 2m43s
- build-linux (aarch64) - 3m23s  
- test-wheels - 10s

Both wheel artifacts produced successfully.

## Compatibility

manylinux_2_34 wheels require glibc 2.34+. This works on:
- Steam Deck (SteamOS/Arch Linux)
- Nobara (Fedora-based)
- Ubuntu 21.04+
- Fedora 34+

Closes #3

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>