### PR TITLE
Simplify PortalCapture API by returning result directly (#14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,18 @@ High-level Rust wrapper for xdg-desktop-portal (https://github.com/bilelmoussaou
 ### pipewire-rs
 Official Rust bindings for PipeWire. Handles stream setup and frame reception.
 
+## API Design Decisions
+
+**Pull model for CaptureStream:** We use polling (`get_frame()`) rather than callbacks. This matches the [scrap](https://lib.rs/crates/scrap) library pattern and is simpler for OCR/translation use cases where you only need the latest frame, not every frame.
+
+**Direct return for PortalCapture:** `select_window()` returns results directly rather than via callback. One-shot blocking operations should return values; callbacks are for streams (like `on_frame_arrived` in windows-capture).
+
+**Comparison with other libraries:**
+- Push (callback): PipeWire native, OBS, windows-capture, screencapturekit-rs
+- Pull (polling): scrap, our library
+
+Both patterns are valid. Pull is appropriate here because missing frames between polls doesn't matter for the interpreter use case.
+
 ## Current Implementation Status
 
 | Component | Status | Notes |

--- a/examples/test_capture.py
+++ b/examples/test_capture.py
@@ -10,21 +10,15 @@ if not is_available():
     print("Not running on Wayland, exiting")
     exit(1)
 
-
-def on_result(success):
-    print(f"Selection result: {success}")
-
-
 # Step 1: Select a window via portal
 print("Opening window picker...")
 portal = PortalCapture()
-portal.select_window(on_result)
+info = portal.select_window()
 
-info = portal.get_stream_info()
 print(f"Stream info: {info}")
 
 if not info:
-    print("\nNo stream info - selection was cancelled or failed.")
+    print("\nNo stream info - selection was cancelled.")
     exit(1)
 
 fd, node_id, width, height = info
@@ -51,7 +45,6 @@ while time.time() - start_time < 5 and not stream.window_invalid:
 
 # Step 4: Stop and cleanup
 stream.stop()
-portal.close()
 
 if stream.window_invalid:
     print("\nWindow was closed during capture.")

--- a/examples/test_portal.py
+++ b/examples/test_portal.py
@@ -9,16 +9,10 @@ if not is_available():
     print("Not running on Wayland, exiting")
     exit(1)
 
-
-def on_result(success):
-    print(f"Selection result: {success}")
-
-
 print("Opening window picker...")
 portal = PortalCapture()
-portal.select_window(on_result)
+info = portal.select_window()
 
-info = portal.get_stream_info()
 print(f"Stream info: {info}")
 
 if info:
@@ -28,4 +22,4 @@ if info:
     print(f"  Window size: {width}x{height}")
     print("\nSuccess! Portal integration is working.")
 else:
-    print("\nNo stream info - selection was cancelled or failed.")
+    print("\nNo stream info - selection was cancelled.")


### PR DESCRIPTION
## Summary

Redesign `select_window()` to return results directly instead of using a callback + `get_stream_info()` pattern.

**Key insight:** `select_window` is a **one-shot blocking operation**, not a stream. Callbacks are for streams (like `on_frame_arrived`). One-shot operations should just return the result.

## API Change

```python
# Before (callback + state) - caused borrow conflicts
def on_result(success):
    if success:
        info = portal.get_stream_info()  # "Already mutably borrowed" panic!
portal.select_window(on_result)

# After (direct return) - simple and safe
info = portal.select_window()  # Returns Optional[(fd, node_id, width, height)]
if info:
    stream = CaptureStream(*info)
```

## Benefits

- No mutable state needed
- No Mutex needed  
- No borrow conflicts possible
- Simpler, more Pythonic API
- Reduced code from ~200 lines to ~140 lines

## Test plan

- [x] `cargo build --release` - Success
- [x] `cargo test --release` - All 4 tests pass
- [x] `cargo clippy -- -D warnings` - Clean
- [x] Manual test - new API works correctly:
  ```python
  portal = PortalCapture()
  info = portal.select_window()
  print(info)  # (10, 84, 2560, 1440)
  ```

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)