### PR TITLE
Fix Issue #17: Don't bundle libpipewire in wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,28 +15,42 @@ jobs:
         include:
           - target: x86_64
             runner: ubuntu-latest
+            manylinux: manylinux_2_34_x86_64
           - target: aarch64
             runner: ubuntu-24.04-arm  # Native ARM64 runner (much faster than QEMU)
+            manylinux: manylinux_2_34_aarch64
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      - name: Build and repair wheels
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/io" \
+            -w /io \
+            quay.io/pypa/${{ matrix.manylinux }} \
+            /bin/bash -c '
+              set -ex
+              # Install build dependencies
+              dnf install -y dnf-plugins-core
+              dnf config-manager --set-enabled crb
+              dnf install -y pipewire-devel clang-devel
 
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          args: --release --out dist
-          manylinux: "2_34"
-          before-script-linux: |
-            # Install PipeWire and clang dev libraries (AlmaLinux 9 / manylinux_2_34)
-            dnf install -y dnf-plugins-core
-            dnf config-manager --set-enabled crb
-            dnf install -y pipewire-devel clang-devel
+              # Install Rust
+              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+              source ~/.cargo/env
+
+              # Install Python build tools
+              /opt/python/cp311-cp311/bin/pip install maturin
+
+              # Build wheel (skip auditwheel, we do it manually)
+              /opt/python/cp311-cp311/bin/maturin build --release --out dist-raw
+
+              # Repair wheel, excluding libpipewire (use system library at runtime)
+              /opt/python/cp311-cp311/bin/pip install auditwheel
+              mkdir -p dist
+              auditwheel repair --exclude libpipewire-0.3.so.0 -w dist dist-raw/*.whl
+            '
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "pipewire-capture"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "ashpd",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipewire-capture"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 description = "Python library for PipeWire video capture with pre-built wheels"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pipewire-capture"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python library for PipeWire video capture with pre-built wheels"
 readme = "README.md"
 license = "MIT"

--- a/python/pipewire_capture/__init__.py
+++ b/python/pipewire_capture/__init__.py
@@ -10,14 +10,13 @@ Example usage:
     if is_available():
         # Window selection via portal
         portal = PortalCapture()
-        portal.select_window(lambda success: print(f"Selected: {success}"))
+        info = portal.select_window()  # Returns (fd, node_id, width, height) or None
 
-        stream_info = portal.get_stream_info()
-        if stream_info:
-            fd, node_id = stream_info
+        if info:
+            fd, node_id, width, height = info
 
             # Frame capture
-            stream = CaptureStream(fd, node_id)
+            stream = CaptureStream(fd, node_id, width, height)
             stream.start()
 
             frame = stream.get_frame()  # numpy array (H, W, 4) BGRA
@@ -25,8 +24,6 @@ Example usage:
                 print(f"Got frame: {frame.shape}")
 
             stream.stop()
-
-        portal.close()
 """
 
 from pipewire_capture._native import (
@@ -41,4 +38,4 @@ __all__ = [
     "is_available",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
## Summary

- Fixes the "can't make support.system handle" error on Ubuntu, Arch, and Steam Deck
- Uses `auditwheel --exclude` to skip bundling libpipewire
- The wheel now links to the system's libpipewire at runtime
- Bumps version to 0.2.1

## Problem

The manylinux wheels bundled `libpipewire-0.3.so` which has hardcoded SPA plugin paths from the build environment (AlmaLinux 9's `/usr/lib64/spa-0.2/`). This caused failures on systems with different paths:

| Distro | SPA Plugin Path | v0.2.0 Status |
|--------|-----------------|---------------|
| Fedora/Nobara | `/usr/lib64/spa-0.2/` | ✅ Works |
| Ubuntu/Debian | `/usr/lib/x86_64-linux-gnu/spa-0.2/` | ❌ Fails |
| Arch/Steam Deck | `/usr/lib/spa-0.2/` | ❌ Fails |

## Solution

Don't bundle libpipewire. Use the system's library which already matches the system's SPA plugins. This is the standard approach for Python packages that depend on running system services (like PyAudio, python-vlc, etc.).

## Test plan

- [ ] CI passes (wheel builds correctly)
- [ ] Install wheel on Ubuntu and verify import works without SPA errors
- [ ] Test `examples/test_capture.py` on Ubuntu

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)