### PR TITLE
Fix auditwheel --exclude not working

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,8 @@ jobs:
               # Install Python build tools
               /opt/python/cp311-cp311/bin/pip install maturin
 
-              # Build wheel (skip auditwheel, we do it manually)
-              /opt/python/cp311-cp311/bin/maturin build --release --out dist-raw
+              # Build wheel (skip auditwheel, we do it manually with --exclude)
+              /opt/python/cp311-cp311/bin/maturin build --release --out dist-raw --auditwheel skip
 
               # Repair wheel, excluding libpipewire (use system library at runtime)
               /opt/python/cp311-cp311/bin/pip install auditwheel
@@ -68,6 +68,11 @@ jobs:
           name: wheels-linux-x86_64
           path: dist
 
+      - name: Install PipeWire runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpipewire-0.3-0
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -77,6 +82,16 @@ jobs:
         run: |
           pip install dist/*.whl numpy
           python -c "from pipewire_capture import is_available; print(f'Available: {is_available()}')"
+          # Verify no bundled libpipewire
+          python -c "
+          import pipewire_capture._native as n
+          import subprocess
+          result = subprocess.run(['ldd', n.__file__], capture_output=True, text=True)
+          print(result.stdout)
+          assert 'libpipewire' in result.stdout
+          assert 'pipewire_capture.libs' not in result.stdout, 'libpipewire should not be bundled!'
+          print('✓ Wheel correctly uses system libpipewire')
+          "
 
   publish:
     needs: [build-linux, test-wheels]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "pipewire-capture"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ashpd",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipewire-capture"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 description = "Python library for PipeWire video capture with pre-built wheels"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pipewire-capture"
-version = "0.2.1"
+dynamic = ["version"]  # Version comes from Cargo.toml
 description = "Python library for PipeWire video capture with pre-built wheels"
 readme = "README.md"
 license = "MIT"

--- a/python/pipewire_capture/__init__.py
+++ b/python/pipewire_capture/__init__.py
@@ -26,6 +26,8 @@ Example usage:
             stream.stop()
 """
 
+from importlib.metadata import version
+
 from pipewire_capture._native import (
     CaptureStream,
     PortalCapture,
@@ -38,4 +40,4 @@ __all__ = [
     "is_available",
 ]
 
-__version__ = "0.2.1"
+__version__ = version("pipewire-capture")


### PR DESCRIPTION
## Summary

- Adds `--auditwheel off` to maturin build command
- Bumps version to 0.2.2

## Problem

v0.2.1 still bundled libpipewire because maturin runs auditwheel automatically by default. The wheel came out already bundled, so `auditwheel repair --exclude` just passed it through unchanged.

## Fix

Add `--auditwheel off` to skip maturin's automatic auditwheel, then our manual repair with `--exclude libpipewire-0.3.so.0` works correctly.

## Test plan

- [ ] CI passes
- [ ] Download wheel artifact and verify no `pipewire_capture.libs/` directory
- [ ] Install and verify `ldd` shows system libpipewire

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)