### PR TITLE
Fix issue #24: Return PortalSession to control session lifetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "pipewire-capture"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "ashpd",
  "libc",

--- a/python/pipewire_capture/__init__.py
+++ b/python/pipewire_capture/__init__.py
@@ -10,13 +10,12 @@ Example usage:
     if is_available():
         # Window selection via portal
         portal = PortalCapture()
-        info = portal.select_window()  # Returns (fd, node_id, width, height) or None
+        session = portal.select_window()  # Returns PortalSession or None
 
-        if info:
-            fd, node_id, width, height = info
-
+        if session:
             # Frame capture
-            stream = CaptureStream(fd, node_id, width, height)
+            stream = CaptureStream(session.fd, session.node_id,
+                                   session.width, session.height)
             stream.start()
 
             frame = stream.get_frame()  # numpy array (H, W, 4) BGRA
@@ -24,6 +23,7 @@ Example usage:
                 print(f"Got frame: {frame.shape}")
 
             stream.stop()
+            session.close()  # Close portal session when done
 """
 
 from importlib.metadata import version
@@ -31,11 +31,13 @@ from importlib.metadata import version
 from pipewire_capture._native import (
     CaptureStream,
     PortalCapture,
+    PortalSession,
     is_available,
 )
 
 __all__ = [
     "PortalCapture",
+    "PortalSession",
     "CaptureStream",
     "is_available",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod portal;
 mod stream;
 
 pub use error::CaptureError;
-pub use portal::PortalCapture;
+pub use portal::{PortalCapture, PortalSession};
 pub use stream::CaptureStream;
 
 /// Check if PipeWire capture is available on this system.
@@ -31,6 +31,7 @@ fn is_available() -> bool {
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(is_available, m)?)?;
     m.add_class::<PortalCapture>()?;
+    m.add_class::<PortalSession>()?;
     m.add_class::<CaptureStream>()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Fixes #24 (CaptureStream.window_invalid becomes true immediately after start)
- Breaking API change: `select_window()` now returns a `PortalSession` object instead of a tuple

## Root Cause
The fix for issue #22 added `session.close().await` which immediately terminated the portal session after getting the fd. This caused the PipeWire stream source to be torn down, making the stream invalid.

## Solution
Return a `PortalSession` object that:
- Holds the fd, node_id, width, height as properties
- Keeps the portal session alive in a background tokio task
- Provides `close()` method to explicitly release resources
- Closes automatically on garbage collection

## New API
```python
session = portal.select_window()  # Returns PortalSession or None
if session:
    stream = CaptureStream(session.fd, session.node_id,
                           session.width, session.height)
    stream.start()
    # ... capture frames ...
    stream.stop()
    session.close()  # Close when done
```

## Test plan
- [x] Test issue #24: stream stays valid for duration of capture
- [x] Test issue #22: multiple select_window() calls work
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test

🤖 Generated with [Claude Code](https://claude.com/claude-code)