### PR TITLE
Fix issue #31: Check D-Bus portal availability instead of WAYLAND_DISPLAY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ pyo3 = { version = "0.22", features = ["extension-module", "abi3-py39"] }
 numpy = "0.22"
 pipewire = "0.8"
 ashpd = { version = "0.11", default-features = false, features = ["tokio"] }
+zbus = { version = "5", default-features = false, features = ["blocking-api"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 parking_lot = "0.12"
 thiserror = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,26 @@ fn init_logging(level: &str) {
 
 /// Check if PipeWire capture is available on this system.
 ///
-/// Returns True if running on Wayland with xdg-desktop-portal support.
+/// Returns True if the ScreenCast portal is available via D-Bus.
+/// This works on Wayland compositors including Gamescope (Steam Deck).
 #[pyfunction]
 fn is_available() -> bool {
-    // Check for WAYLAND_DISPLAY environment variable
-    std::env::var("WAYLAND_DISPLAY").is_ok()
-    // TODO: Also check for portal availability via D-Bus
+    // Check if ScreenCast portal is available via D-Bus introspection
+    let Ok(conn) = zbus::blocking::Connection::session() else {
+        return false;
+    };
+
+    conn.call_method(
+        Some("org.freedesktop.portal.Desktop"),
+        "/org/freedesktop/portal/desktop",
+        Some("org.freedesktop.DBus.Introspectable"),
+        "Introspect",
+        &(),
+    )
+    .ok()
+    .and_then(|reply| reply.body().deserialize::<String>().ok())
+    .map(|xml| xml.contains("org.freedesktop.portal.ScreenCast"))
+    .unwrap_or(false)
 }
 
 /// Python module definition.
@@ -67,31 +81,12 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
 mod tests {
     use super::*;
 
-    // Note: These tests modify environment variables, so they must run serially.
-    // We combine them into one test to avoid race conditions.
     #[test]
-    fn test_is_available() {
-        // Save original value
-        let original = std::env::var("WAYLAND_DISPLAY").ok();
-
-        // Test without WAYLAND_DISPLAY
-        std::env::remove_var("WAYLAND_DISPLAY");
-        assert!(
-            !is_available(),
-            "Should return false when WAYLAND_DISPLAY is not set"
-        );
-
-        // Test with WAYLAND_DISPLAY
-        std::env::set_var("WAYLAND_DISPLAY", "wayland-0");
-        assert!(
-            is_available(),
-            "Should return true when WAYLAND_DISPLAY is set"
-        );
-
-        // Restore original value
-        match original {
-            Some(val) => std::env::set_var("WAYLAND_DISPLAY", val),
-            None => std::env::remove_var("WAYLAND_DISPLAY"),
-        }
+    fn test_is_available_does_not_panic() {
+        // is_available() checks D-Bus for ScreenCast portal availability.
+        // We can't easily mock D-Bus, so just verify it doesn't panic.
+        // On systems with xdg-desktop-portal, this returns true.
+        // On systems without D-Bus session bus, this returns false.
+        let _result = is_available();
     }
 }


### PR DESCRIPTION
## Summary

- Replace `WAYLAND_DISPLAY` env var check with D-Bus introspection for ScreenCast portal
- Works on Gamescope (Steam Deck) even without `WAYLAND_DISPLAY` set
- Returns false if portal is unavailable, not just if env var is missing

## Problem

The old `is_available()` only checked for `WAYLAND_DISPLAY` env var:
- Gamescope doesn't set it → false negative
- Env var set but portal broken → false positive

## Solution

Check if `org.freedesktop.portal.ScreenCast` interface exists via D-Bus introspection.

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `is_available()` returns `True` on Ubuntu/GNOME Wayland
- [ ] Needs testing on Gamescope/Steam Deck

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)