### PR TITLE
Fix initial frame throttle causing capture stall on single-buffer setups

### DIFF
--- a/examples/test_capture.py
+++ b/examples/test_capture.py
@@ -42,7 +42,8 @@ while time.time() - start_time < 5 and not stream.window_invalid:
     frame = stream.get_frame()
     if frame is not None:
         frame_count += 1
-        print(f"  Frame {frame_count}: shape={frame.shape}, dtype={frame.dtype}")
+        non_zero = frame.any()
+        print(f"  Frame {frame_count}: shape={frame.shape}, dtype={frame.dtype}, has_content={non_zero}")
     time.sleep(0.1)
 
 # Step 4: Stop and cleanup

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -45,7 +45,8 @@ impl Default for SharedState {
             height: 0,
             stream_ended: false,
             window_closed: false,
-            last_capture_time: Instant::now(),
+            // Start in the past so the first frame is never throttled
+            last_capture_time: Instant::now() - std::time::Duration::from_secs(1),
         }
     }
 }
@@ -542,12 +543,14 @@ fn on_process(stream: &StreamRef, data: &mut StreamUserData) {
     // Use raw buffer API to access spa_buffer
     let pw_buffer = unsafe { stream.dequeue_raw_buffer() };
     if pw_buffer.is_null() {
+        debug!("dequeue_raw_buffer returned null");
         return;
     }
 
     // Get the spa_buffer from pw_buffer
     let spa_buffer = unsafe { (*pw_buffer).buffer };
     if spa_buffer.is_null() {
+        debug!("spa_buffer is null");
         unsafe { stream.queue_raw_buffer(pw_buffer) };
         return;
     }
@@ -559,6 +562,7 @@ fn on_process(stream: &StreamRef, data: &mut StreamUserData) {
     };
 
     if !should_capture {
+        debug!("throttled, skipping frame");
         unsafe { stream.queue_raw_buffer(pw_buffer) };
         return;
     }
@@ -566,12 +570,14 @@ fn on_process(stream: &StreamRef, data: &mut StreamUserData) {
     // Get buffer data array
     let n_datas = unsafe { (*spa_buffer).n_datas };
     if n_datas == 0 {
+        debug!("spa_buffer has no data planes (n_datas=0)");
         unsafe { stream.queue_raw_buffer(pw_buffer) };
         return;
     }
 
     let datas_ptr = unsafe { (*spa_buffer).datas };
     if datas_ptr.is_null() {
+        debug!("spa_buffer datas pointer is null");
         unsafe { stream.queue_raw_buffer(pw_buffer) };
         return;
     }
@@ -599,7 +605,14 @@ fn on_process(stream: &StreamRef, data: &mut StreamUserData) {
     match data_type {
         SPA_DATA_MEMPTR => {
             // Memory-mapped buffer - direct access
-            if !first_data.data.is_null() && !first_data.chunk.is_null() {
+            let data_null = first_data.data.is_null();
+            let chunk_null = first_data.chunk.is_null();
+            if data_null || chunk_null {
+                debug!(
+                    data_null,
+                    chunk_null, "MEMPTR buffer has null data or chunk pointer"
+                );
+            } else {
                 let chunk = unsafe { &*first_data.chunk };
                 let size = chunk.size as usize;
                 let offset = chunk.offset as usize;
@@ -610,6 +623,8 @@ fn on_process(stream: &StreamRef, data: &mut StreamUserData) {
                     let mut shared = data.shared.lock();
                     shared.frame_buffer = Some(frame_slice.to_vec());
                     shared.last_capture_time = now;
+                } else {
+                    debug!(size, offset, "MEMPTR buffer has zero size");
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Fix capture stall on single-buffer PipeWire setups (e.g. Bazzite/KDE with PipeWire 1.4.10) by initializing `last_capture_time` to 60 seconds in the past instead of `Instant::now()`
- Add debug logging to all early-return paths in `on_process` for easier diagnosis of frame delivery issues
- Improve test to validate frames contain actual pixel data

## Test plan

- [x] Run `examples/test_capture.py` on Bazzite 43 (PipeWire 1.4.10, KDE Plasma 6.5.5)
- [x] Verify frames are captured (47 frames in 5s, was 0 before fix)
- [x] Verify all frames have content (`has_content=True`)

Fixes #35