### PR TITLE
Bump version to 0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "pipewire-capture"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "ashpd",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pipewire-capture"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 license = "MIT"
 description = "Python library for PipeWire video capture with pre-built wheels"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,29 @@
+# Release Process
+
+## Steps
+
+1. **Create a version bump PR**
+   - Update `version` in `Cargo.toml`
+   - Run `cargo check` to update `Cargo.lock`
+   - Commit and open a PR
+
+2. **Merge the PR**
+   - Ensure CI passes (lint, build, test-python)
+   - Squash merge into `main`
+
+3. **Create a GitHub Release**
+   - Go to [Releases](https://github.com/bquenin/pipewire-capture/releases/new)
+   - Create a new tag matching the version (e.g., `v0.2.9`)
+   - Target: `main`
+   - Write release notes describing the changes
+   - Publish the release
+
+4. **Automated publishing**
+   - The `publish.yml` workflow triggers on release publication
+   - Builds manylinux wheels for x86_64 and aarch64
+   - Tests that wheels don't bundle libpipewire
+   - Publishes to [PyPI](https://pypi.org/project/pipewire-capture/) via trusted publishing (OIDC)
+
+## Version Scheme
+
+Follows [Semantic Versioning](https://semver.org/). The version in `Cargo.toml` is the single source of truth — `pyproject.toml` reads it dynamically via maturin.


### PR DESCRIPTION
## Summary
- Bump version from 0.2.8 to 0.2.9
- Add RELEASING.md documenting the release process

## Changes in this release
- Fix PipeWire capture stall on single-buffer setups (#35, #36)